### PR TITLE
refactor(badge): RelationBadge를 Badge로 변경하고 구조 개선

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -1,0 +1,29 @@
+import styles from "./Badge.module.css";
+
+const Badge = ({ text, color }) => {
+  return (
+    <span
+      className={styles.badge}
+      style={{ backgroundColor: BADGE_COLORS[color] }}
+    >
+      {text}
+    </span>
+  );
+};
+
+const BADGE_COLORS = {
+  primary: "var(--color-blue-100)",
+  secondary: "var(--color-gray-100)",
+  success: "var(--color-green-100)",
+  warning: "var(--color-beige-500)",
+  danger: "var(--color-error)",
+  info: "var(--color-green-300)",
+
+  like: "var(--color-green-200)",
+  dislike: "var(--color-gray-400)",
+  new: "var(--color-purple-100)",
+  premium: "var(--color-beige-200)",
+  verified: "var(--color-blue-200)",
+};
+
+export default Badge;

--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -1,0 +1,12 @@
+.badge {
+  display: inline-flex;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+  padding: 0 0.5rem;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 0.75rem;
+  white-space: nowrap;
+  max-width: fit-content;
+}

--- a/src/components/RelationBadge/RelationBadge.jsx
+++ b/src/components/RelationBadge/RelationBadge.jsx
@@ -1,0 +1,37 @@
+import styles from "./RelationBadge.module.css";
+
+const RELATION_STYLES = {
+  friend: {
+    backgroundColor: "var(--color-blue-100)",
+    color: "var(--color-blue-500)",
+  },
+  colleague: {
+    backgroundColor: "var(--color-purple-100)",
+    color: "var(--color-purple-600)",
+  },
+  acquaintance: {
+    backgroundColor: "var(--color-beige-100)",
+    color: "var(--color-beige-500)",
+  },
+  family: {
+    backgroundColor: "var(--color-green-100)",
+    color: "var(--color-green-500)",
+  },
+};
+
+const RELATION_LABELS = {
+  friend: "친구",
+  colleague: "동료",
+  acquaintance: "지인",
+  family: "가족",
+};
+
+const RelationBadge = ({ relation }) => {
+  return (
+    <span className={styles.badge} style={RELATION_STYLES[relation]}>
+      {RELATION_LABELS[relation]}
+    </span>
+  );
+};
+
+export default RelationBadge;

--- a/src/components/RelationBadge/RelationBadge.module.css
+++ b/src/components/RelationBadge/RelationBadge.module.css
@@ -1,0 +1,7 @@
+.badge {
+  width: 2.5625rem;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#16

## 📝작업 내용

## RelationBadge를 Badge로 변경하고 구조 개선

기존 RelationBadge 컴포넌트를 Badge로 변경하고, 구조를 개선하였습니다.
- 브랜치명을 `feature/relation-badge` -> `feature/badge`로 변경
- 컴포넌트 파일명과 스타일 파일명을 `RelationBadge` → `Badge`로 변경
- `RELATION_STYLES` 및 `RELATION_LABELS` 객체를 제거하고 `BADGE_COLORS`로 통합
- `relation` prop 대신 `text`와 `color` props를 받아서 더 유연하게 사용할 수 있도록 개선
- 불필요한 하드코딩을 제거하고, 다양한 배지 스타일을 적용할 수 있도록 확장 가능하도록 수정