### PR TITLE
fix(pages): 생성된 롤링 페이퍼 페이지 통합 테스트 피드백 반영

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
       href="/favicon/favicon-16x16.png"
     />
     <link rel="manifest" href="/favicon/manifest.json" />
+
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
     <meta name="theme-color" content="#ffffff" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "hasInstallScript": true,
       "dependencies": {
         "clsx": "^2.1.1",
+        "dompurify": "^3.2.4",
         "emoji-picker-react": "^4.12.2",
+        "html-react-parser": "^5.2.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-quill-new": "^3.3.3",
@@ -1650,7 +1652,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1665,6 +1667,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
@@ -2285,7 +2293,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2416,6 +2424,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -2475,7 +2542,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3561,6 +3627,64 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.13.tgz",
+      "integrity": "sha512-B7JonBuAfG32I7fDouUQEogBrz3jK9gAuN1r1AaXpED6dIhtg/JwiSRhjGL7aOJwRz3HU4efowCjQBaoXiREqg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.2.tgz",
+      "integrity": "sha512-yA5012CJGSFWYZsgYzfr6HXJgDap38/AEP4ra8Cw+WHIi2ZRDXRX/QVYdumRf1P8zKyScKd6YOrWYvVEiPfGKg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.13",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.16"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -3623,6 +3747,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5048,6 +5177,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-quill-new": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.4.1.tgz",
@@ -5732,6 +5866,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
+      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "dependencies": {
+        "style-to-object": "1.0.8"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
+      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "dompurify": "^3.2.4",
     "emoji-picker-react": "^4.12.2",
+    "html-react-parser": "^5.2.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-quill-new": "^3.3.3",

--- a/src/components/EmojiBox/EmojiBox.module.css
+++ b/src/components/EmojiBox/EmojiBox.module.css
@@ -34,18 +34,6 @@
 
 /* Mobile (Max 767px) */
 @media (max-width: 767px) {
-  .emojiBox .emojiHiddenList {
-    top: 2.5rem;
-    width: 12.5rem;
-    min-height: 6.125rem;
-    max-height: 9.375rem;
-    padding: 1rem;
-  }
-
-  .emojiBox .emojiHiddenList ul {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
   .emojiBox .badge {
     font-size: 0.875rem;
     padding: 0.25rem 0.5rem;

--- a/src/components/EmojiBox/EmojiListButton/EmojiListButton.jsx
+++ b/src/components/EmojiBox/EmojiListButton/EmojiListButton.jsx
@@ -4,7 +4,6 @@ import clsx from "clsx";
 
 import DropdownIcon from "../../../assets/icons/arrow-down.svg";
 import PurplePaperPlane from "../../../assets/imgs/paperplane.png";
-import useIntersection from "../../../hooks/useIntersection";
 import useOutsideClick from "../../../hooks/useOutsideClick";
 import AsyncStateRenderer from "../../AsyncStateRenderer/AsyncStateRenderer";
 import Button from "../../Button/Button";
@@ -16,20 +15,11 @@ const EmojiListButton = ({
   invisibleReactionList,
   isLoading,
   isError,
-  next,
-  onUpdate,
   onRetryRequest,
 }) => {
   const popoverRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
   useOutsideClick(popoverRef, () => setIsOpen(false));
-  const intersectingElementRef = useIntersection(
-    {
-      condition: !isLoading && next,
-      callback: onUpdate,
-    },
-    [isLoading, next, onUpdate],
-  );
 
   const isEmpty =
     !isLoading &&
@@ -80,8 +70,10 @@ const EmojiListButton = ({
             </AsyncStateRenderer.Error>
             <AsyncStateRenderer.Empty>
               <li className={styles.wrapper}>
-                <img src={PurplePaperPlane} alt="보라색 종이비행기" />
-                이모지가 없어요.
+                <p className={styles.transparentEmoji}>🫥</p>
+                <p className={styles.emptyDescription}>
+                  아직 들어온 이모지가 없어요. 😢
+                </p>
               </li>
             </AsyncStateRenderer.Empty>
             <AsyncStateRenderer.Content>
@@ -91,7 +83,6 @@ const EmojiListButton = ({
                   <span>{count}</span>
                 </li>
               ))}
-              <div ref={intersectingElementRef} />
             </AsyncStateRenderer.Content>
           </AsyncStateRenderer>
         </ul>

--- a/src/components/EmojiBox/EmojiListButton/EmojiListButton.module.css
+++ b/src/components/EmojiBox/EmojiListButton/EmojiListButton.module.css
@@ -60,8 +60,11 @@
   color: var(--color-gray-500);
 }
 
-.wrapper p {
-  font-size: 1rem;
+.wrapper .transparentEmoji {
+  font-size: 4rem;
+}
+.wrapper .emptyDescription {
+  font-size: var(--font-size-20);
 }
 
 .wrapper .retryButton {
@@ -77,6 +80,10 @@
   .emojiDropdown {
     width: 15rem;
     grid-template-columns: repeat(3, 1fr);
+  }
+
+  .badge:nth-child(n + 7) {
+    display: none;
   }
 }
 

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,3 +1,7 @@
+import clsx from "clsx";
+
+import { FONT_MAP } from "../../constants/fonts";
+
 import styles from "./Modal.module.css";
 
 const Modal = ({
@@ -9,10 +13,11 @@ const Modal = ({
   date,
   bodyText,
   fromLabel,
+  font,
 }) => {
   if (!isModalOpen) return null;
   return (
-    <div className={styles.modalOverlay} onClick={onClose}>
+    <div className={clsx(styles.modalOverlay, styles[font])} onClick={onClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.modalHeader}>
           <div className={styles.modalHeaderUserInfo}>
@@ -28,7 +33,7 @@ const Modal = ({
           <p className={styles.date}>{date}</p>
         </div>
         <hr className={styles.divider} />
-        <p className={styles.bodyText}>{bodyText}</p>
+        <div className={styles.bodyText}>{bodyText}</div>
         <button onClick={onClose} className={styles.button}>
           확인
         </button>

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -109,6 +109,22 @@
   background-color: var(--color-purple-700);
 }
 
+.notoSans {
+  font-family: "Noto Sans, sans-serif";
+}
+
+.pretendard {
+  font-family: "Pretendard, sans-serif";
+}
+
+.nanumMyeongjo {
+  font-family: "Nanum Myeongjo, serif";
+}
+
+.nanumSonPyeonJi {
+  font-family: "NanumSonPyeonJiCe, cursive";
+}
+
 @media (max-width: 768px) {
   .modal {
     width: 23.125rem;

--- a/src/components/RollingPaperCard/RollingPaperCard.jsx
+++ b/src/components/RollingPaperCard/RollingPaperCard.jsx
@@ -19,6 +19,7 @@ const Card = ({
   badge,
   prefix,
   onClick,
+  className,
   ...props
 }) => {
   const navigate = useNavigate();
@@ -42,7 +43,13 @@ const Card = ({
 
   return (
     <div
-      className={clsx(styles.card, { [styles.addCard]: type === "add" })}
+      className={clsx(
+        styles.card,
+        {
+          [styles.addCard]: type === "add",
+        },
+        className,
+      )}
       onClick={handleClick}
       {...props}
     >

--- a/src/components/RollingPaperCardList/RollingPaperCardList.jsx
+++ b/src/components/RollingPaperCardList/RollingPaperCardList.jsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 
+import clsx from "clsx";
+
 import BinIcon from "../../assets/icons/delete.svg";
+import { FONT_MAP } from "../../constants/fonts";
 import useIntersection from "../../hooks/useIntersection";
 import { formatDateWithDots } from "../../utils/formatter";
 import { makeBadge } from "../../utils/mapper";
 import Badge from "../Badge/Badge";
 import Card from "../Card/Card";
 import Modal from "../Modal/Modal";
-import RollingPaperCard from "../RollingPaperCard/RollingPaperCard";
 import Spinner from "../Spinner/Spinner";
 import HtmlContentDisplay from "../TextEditor/HtmlContentDisplay/HtmlContentDisplay";
 
@@ -41,7 +43,15 @@ const RollingPaperCardList = ({
     <>
       {messages.map(
         (
-          { id, profileImageURL, sender, relationship, content, createdAt },
+          {
+            id,
+            profileImageURL,
+            sender,
+            relationship,
+            content,
+            createdAt,
+            font,
+          },
           index,
         ) => (
           <Card
@@ -62,7 +72,7 @@ const RollingPaperCardList = ({
             middle={
               <div className={styles.cardMiddle}>
                 <hr />
-                <div className={styles.content}>
+                <div className={clsx(styles[FONT_MAP[font]], styles.content)}>
                   <HtmlContentDisplay htmlContent={content} />
                 </div>
               </div>
@@ -122,7 +132,7 @@ const RollingPaperCardTop = ({
 
 const makeModalProps = (messageData) => {
   if (messageData) {
-    const { profileImageURL, sender, relationship, createdAt, content } =
+    const { profileImageURL, sender, relationship, createdAt, content, font } =
       messageData;
 
     return {
@@ -131,6 +141,7 @@ const makeModalProps = (messageData) => {
       badge: <Badge {...makeBadge(relationship)} />,
       date: formatDateWithDots(createdAt),
       bodyText: <HtmlContentDisplay htmlContent={content} />,
+      font,
     };
   }
 };

--- a/src/components/RollingPaperCardList/RollingPaperCardList.jsx
+++ b/src/components/RollingPaperCardList/RollingPaperCardList.jsx
@@ -9,6 +9,7 @@ import Card from "../Card/Card";
 import Modal from "../Modal/Modal";
 import RollingPaperCard from "../RollingPaperCard/RollingPaperCard";
 import Spinner from "../Spinner/Spinner";
+import HtmlContentDisplay from "../TextEditor/HtmlContentDisplay/HtmlContentDisplay";
 
 import styles from "./RollingPaperCardList.module.css";
 
@@ -61,7 +62,9 @@ const RollingPaperCardList = ({
             middle={
               <div className={styles.cardMiddle}>
                 <hr />
-                <p className={styles.content}>{content}</p>
+                <div className={styles.content}>
+                  <HtmlContentDisplay htmlContent={content} />
+                </div>
               </div>
             }
             bottom={
@@ -127,7 +130,7 @@ const makeModalProps = (messageData) => {
       title: sender,
       badge: <Badge {...makeBadge(relationship)} />,
       date: formatDateWithDots(createdAt),
-      bodyText: content,
+      bodyText: <HtmlContentDisplay htmlContent={content} />,
     };
   }
 };

--- a/src/components/RollingPaperCardList/RollingPaperCardList.module.css
+++ b/src/components/RollingPaperCardList/RollingPaperCardList.module.css
@@ -103,6 +103,22 @@
   color: var(--color-gray-300);
 }
 
+.notoSans {
+  font-family: "Noto Sans, sans-serif";
+}
+
+.pretendard {
+  font-family: "Pretendard, sans-serif";
+}
+
+.nanumMyeongjo {
+  font-family: "Nanum Myeongjo, serif";
+}
+
+.nanumSonPyeonJi {
+  font-family: "NanumSonPyeonJiCe, cursive";
+}
+
 /* Tablet (768px ~ 1024px) */
 @media (max-width: 1024px) {
   .cardMiddle .content {

--- a/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.css
+++ b/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.css
@@ -1,0 +1,25 @@
+.ql-align-right {
+  text-align: right;
+}
+.ql-align-center {
+  text-align: center;
+}
+.ql-align-justify {
+  text-align: justify;
+}
+
+ol {
+  list-style-type: decimal;
+}
+
+li[data-list] {
+  margin-left: 1rem;
+}
+
+li[data-list="ordered"] {
+  list-style-type: decimal;
+}
+
+li[data-list="bullet"] {
+  list-style-type: disc;
+}

--- a/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.jsx
+++ b/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+import DOMPurify from "dompurify";
+import parse from "html-react-parser";
+import "react-quill-new/dist/quill.snow.css";
+import "./HtmlContentDisplay.css";
+
+const HtmlContentDisplay = ({ htmlContent }) => {
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    // 클라이언트 사이드에서만 파싱 (하이드레이션 문제 방지)
+    const sanitizedContent = DOMPurify.sanitize(htmlContent);
+    setContent(sanitizedContent);
+  }, [htmlContent]);
+
+  return <div className="quill-content">{content ? parse(content) : null}</div>;
+};
+
+export default HtmlContentDisplay;

--- a/src/constants/fonts.js
+++ b/src/constants/fonts.js
@@ -1,0 +1,6 @@
+export const FONT_MAP = {
+  "Noto Sans": "notoSans",
+  "Pretendard": "pretendard",
+  "나눔명조": "nanumMyeongjo",
+  "나눔손글씨 손편지체": "nanumSonPyeonJi",
+};

--- a/src/pages/PostItemPage/PostItemPage.jsx
+++ b/src/pages/PostItemPage/PostItemPage.jsx
@@ -110,11 +110,7 @@ const PostItemPage = () => {
           selectedItemsToDelete={selectedItemsToDelete}
         />
       </div>
-      <div
-        className={clsx(styles.messageContainer, {
-          [styles.block]: isError || isEmptyMessage,
-        })}
-      >
+      <div className={styles.messageContainer}>
         <AsyncStateRenderer
           isLoading={isLoading}
           isError={isError || messageError.isError}
@@ -127,6 +123,11 @@ const PostItemPage = () => {
             <ErrorDisplay onRetry={handleRefreshMessages} />
           </AsyncStateRenderer.Error>
           <AsyncStateRenderer.Empty>
+            <RollingPaperCard
+              type="add"
+              id={recipientId}
+              className={styles.emptyAddCard}
+            />
             <EmptyDisplay />
           </AsyncStateRenderer.Empty>
           <AsyncStateRenderer.Content>
@@ -164,7 +165,7 @@ const ErrorDisplay = ({ onRetry }) => (
 );
 
 const EmptyDisplay = () => (
-  <div className={styles.errorMessageWrapper}>
+  <div className={clsx(styles.errorMessageWrapper, styles.emptyMessage)}>
     <img src={EmptyPaperplane} alt="보라색 종이비행기" />
     <p>받은 메시지가 없습니다.</p>
   </div>

--- a/src/pages/PostItemPage/PostItemPage.module.css
+++ b/src/pages/PostItemPage/PostItemPage.module.css
@@ -19,34 +19,33 @@
   width: 100%;
 }
 
-.block {
-  display: block;
-  grid-template-columns: none;
-}
-
 .errorMessageWrapper {
+  grid-column: 1 / 4;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   gap: 1rem;
-  width: 100%;
-  height: 20rem;
+  padding: 2rem;
   background-color: var(--color-white);
   border-radius: 1rem;
   border: 0.0625rem solid var(--color-gray-300);
 }
 
+.emptyMessage {
+  grid-column: 2 / 4;
+}
+
 .errorMessageWrapper img {
-  height: 10rem;
+  height: 8rem;
 }
 
 .errorMessageWrapper p {
-  font-size: var(--font-size-20);
+  font-size: var(--font-size-18);
 }
 
 .retryButton {
-  width: 12rem;
+  width: 15rem;
   height: auto;
 }
 

--- a/src/pages/PostItemPage/PostItemPageModeButtons/PostItemPageModeButtons.jsx
+++ b/src/pages/PostItemPage/PostItemPageModeButtons/PostItemPageModeButtons.jsx
@@ -186,7 +186,6 @@ const PostItemPageModeButtons = ({
         message={toastState.message}
         icon={toastState.icon}
       />
-      ;
     </>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#78 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 반영 내용
- [x] 에디터로부터 저장된 HTML을 메시지에도 그대로 표현하기
- [x] 헤더의 이모지 박스에 이모지가 있어서 없다고 표시가 됨
- [x] 메시지가 없는 경우, 메시지 보내기 카드를 추가로 렌더링하기

### 추가 구현사항
#### `<HtmlContentDisplay />`
텍스트 에디터에서 반환한 HTML 형태의 문자열을 노드로 파싱해줍니다.
- props
  - `content`: `string`
    - 파싱할 문자열을 전달받습니다.
- `dompurify` 패키지로 새니타이징을 한 뒤, `html-react-parser` 패키지로 파싱을 합니다.
- `import "react-quill-new/dist/quill.snow.css";`에서 적용안되는 CSS 스타일이 존재
- `css` 파일로 일부 수동으로 직접 스타일을 적용했습니다.
<img width="629" alt="image" src="https://github.com/user-attachments/assets/954942a7-1efd-4714-a773-e120c560a5ec" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
