### PR TITLE
fix(Message): MessagePage 버그 수정 및 피드백 반영

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -1,36 +1,47 @@
+import { forwardRef } from "react";
+
 import arrowDown from "../../assets/icons/arrow-down.svg";
 import arrowTop from "../../assets/icons/arrow-top.svg";
 
 import styles from "./Dropdown.module.css";
 
-const Dropdown = ({ selectedText, isOpen, setIsOpen, items, onSelect }) => {
-  return (
-    <div className={styles.dropdownContainer}>
-      <div
-        role="button"
-        className={styles.dropdown}
-        onClick={() => setIsOpen((prev) => !prev)}
-      >
-        <span>{selectedText}</span>
-        <div className={styles.iconDiv}>
-          <img src={isOpen ? arrowTop : arrowDown} alt="arrow-icons" />
+const Dropdown = forwardRef(
+  ({ selectedText, isOpen, setIsOpen, items, onSelect }, ref) => {
+    const handleDropdownClick = (e) => {
+      if (e.target !== e.currentTarget) {
+        return;
+      }
+      setIsOpen((prev) => !prev);
+    };
+
+    return (
+      <div className={styles.dropdownContainer} ref={ref}>
+        <div
+          role="button"
+          className={styles.dropdown}
+          onClick={handleDropdownClick}
+        >
+          <span>{selectedText}</span>
+          <div className={styles.iconDiv}>
+            <img src={isOpen ? arrowTop : arrowDown} alt="arrow-icons" />
+          </div>
         </div>
+        {isOpen && (
+          <ul className={styles.dropdownMenu}>
+            {items.map((item, index) => (
+              <li
+                key={index}
+                className={styles.dropdownList}
+                onClick={() => onSelect(item)}
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-      {isOpen && (
-        <ul className={styles.dropdownMenu}>
-          {items.map((item, index) => (
-            <li
-              key={index}
-              className={styles.dropdownList}
-              onClick={() => onSelect(item)}
-            >
-              {item}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-};
+    );
+  },
+);
 
 export default Dropdown;

--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -8,7 +8,7 @@ import styles from "./Dropdown.module.css";
 const Dropdown = forwardRef(
   ({ selectedText, isOpen, setIsOpen, items, onSelect }, ref) => {
     const handleDropdownClick = (e) => {
-      if (e.target !== e.currentTarget) {
+      if (!e.currentTarget.contains(e.target)) {
         return;
       }
       setIsOpen((prev) => !prev);

--- a/src/components/TextEditor/TextEditor.module.css
+++ b/src/components/TextEditor/TextEditor.module.css
@@ -28,13 +28,11 @@
 :global(.ql-toolbar button) {
   width: 2rem;
   height: 2rem;
-  border: none;
   background: transparent;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.25rem;
 }
 
 :global(.ql-container) {
@@ -56,12 +54,6 @@
   width: 100%;
 }
 
-@media (max-width: 1024px) {
-  .textEditor {
-    max-width: 40rem;
-  }
-}
-
 @media (max-width: 768px) {
   .textEditor {
     min-width: 18.75rem;
@@ -70,6 +62,9 @@
   :global(.ql-toolbar) {
     flex-wrap: wrap;
     height: auto;
+  }
+  :global(.ql-toolbar .ql-formats) {
+    margin-right: 0 !important;
   }
 }
 

--- a/src/pages/MessagePage/MessagePage.module.css
+++ b/src/pages/MessagePage/MessagePage.module.css
@@ -1,7 +1,6 @@
 .container {
-  max-width: 45rem;
   margin: 0 auto;
-  padding: 2rem;
+  padding-top: 2rem;
 }
 
 .title {
@@ -35,10 +34,6 @@
   display: flex;
   align-items: center;
   gap: 1.5rem;
-}
-
-.largeProfile {
-  flex-shrink: 0;
 }
 
 .profileText {
@@ -88,18 +83,9 @@
   z-index: 10;
 }
 
-@media (max-width: 767px) {
-  .rightSection {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(2, auto);
-    gap: 0.5rem;
-    width: fit-content;
-  }
-}
-
 .relationWrap,
 .fontWrap {
+  width: fit-content;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -131,17 +117,37 @@
   text-align: center;
 }
 
+.largeProfile {
+  flex-shrink: 0;
+  position: relative;
+  width: 5rem;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinnerOverlay {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
 @media (max-width: 1024px) {
   .container {
-    max-width: 45rem;
-    padding: 1.5rem;
+    padding-top: 1.5rem;
   }
 }
 
 @media (max-width: 767px) {
+  .rightSection {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    grid-template-rows: repeat(2, auto);
+    gap: 0.5rem;
+    width: fit-content;
+  }
+
   .container {
-    max-width: 20rem;
-    padding: 1rem;
+    padding-top: 3.125rem;
   }
 
   .fromWrap,


### PR DESCRIPTION
## #️⃣연관된 이슈

#82

## 📝작업 내용

- 스타일링 이슈 및 피드백
  - 반응형 태블릿에서 에디터의 가로폭이 조금 모자른 것 같아요. [해결완료]
  - 반응형 모바일에서 에디터의 메뉴에서 줄바꿈이 발생해요. [해결완료]
  - 반응형 태블릿, 모바일에서 내부 컨텐츠들이 부모요소와 여백을 벗어나요. [해결완료]
  - 반응형 모바일 상단의 여백이 디자인보다 작어요. [해결 완료]
  - 텍스트 에디터에서 글자 색상 부분에서 하얀색은 불필요한거 같아요, 대안으로는 하얀색을 눌렀을 때, 텍스트 입력창을 검정색으로 변경해서 흰 글씨가 보일 수 있으면 좋을 것 같아요. [수정 불필요, 이슈 이미지 참고]

- 기술적 이슈 및 피드백
  - From 입력창에서 에러메시지 표시 중 다시 입력 시에 에러 메시지가 사라지는 것이 아니라, 입력 후 다른 곳을 클릭하면 사라져요. [해결완료]
  - 상대와의 관계, 폰트선택 드롭다운이 열린 상태에서 외부를 클릭하면 닫히기를 의도하셨지만 외부를 클릭해도 닫히지 않는 공간이 있어요. [해결완료]
  - 이미지 버튼을 누를때 왼쪽 큰 이미지에 반영되는 시간이 있어서 스피너 처리 해주면 좋을 거 같아요. [해결완료]
  - 기술적으로 아쉬운 부분이긴 합니다만..! Input에 입력을 하거나, 드로다운을 열었다 닫거나 할 때, 페이지 전체가 리렌더링이 발생해요. 관리하는 상태의 범위를 지역적으로 좁혀서 필요한 곳에만 리렌더링 할 수 있도록 해보는 것도 좋을 것 같아요. [추후 해결, 이슈 이미지 참고]


## 💬리뷰 요구사항
 - 수정 한 이슈들 확인 후 리뷰 부탁드립니다.!