### PR TITLE
fix(pages): ListPage 마운트 시 스크롤 최상단 이동 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,6 +3333,7 @@
       "version": "12.5.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.5.0.tgz",
       "integrity": "sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==",
+      "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.5.0",
         "motion-utils": "^12.5.0",

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { useNavigate } from "react-router-dom";
 
@@ -11,6 +11,11 @@ import styles from "./ListPage.module.css";
 
 const ListPage = () => {
   const navigate = useNavigate();
+
+  // 페이지가 마운트될 때 스크롤을 최상단으로 이동
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   // 한 번에 보여줄 카드 개수
   const itemsToShow = 4;


### PR DESCRIPTION
## #️⃣연관된 이슈

#80 

## 📝작업 내용

- 홈 페이지에서 스크롤을 아래로 쭉 내리고 구경하러가기 버튼 누르면 ListPage에서 스크롤위치가 상단으로 초기화 되지 않아서 불편했습니다. 이를 useEffect 훅으로 관리합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

