### PR TITLE
fix(pages): 생성된 롤링페이퍼 페이지 내 추가 버그 수정 건

### DIFF
--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -21,6 +21,7 @@
 .middle {
   flex: 1;
   display: flex;
+  overflow: hidden;
 }
 
 .bottom {

--- a/src/components/EmojiBox/EmojiPickerButton/EmojiPickerButton.jsx
+++ b/src/components/EmojiBox/EmojiPickerButton/EmojiPickerButton.jsx
@@ -28,7 +28,15 @@ const EmojiPickerButton = ({ onClick }) => {
         <span className={styles.buttonText}>추가</span>
       </button>
       <div className={styles.emojiBox}>
-        {isOpen && <EmojiPicker onEmojiClick={handleClickPickEmoji} />}
+        {isOpen && (
+          <EmojiPicker
+            height="22rem"
+            lazyLoadEmojis
+            searchDisabled
+            skinTonesDisabled
+            onEmojiClick={handleClickPickEmoji}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/EmojiBox/EmojiPickerButton/EmojiPickerButton.module.css
+++ b/src/components/EmojiBox/EmojiPickerButton/EmojiPickerButton.module.css
@@ -42,4 +42,8 @@
   .button .buttonText {
     display: none;
   }
+
+  .emojiBox {
+    right: -5rem;
+  }
 }

--- a/src/components/RollingPaperCardList/RollingPaperCardList.jsx
+++ b/src/components/RollingPaperCardList/RollingPaperCardList.jsx
@@ -184,7 +184,7 @@ const makeModalProps = (messageData) => {
     title: sender || "",
     badge: relationship ? <Badge {...makeBadge(relationship)} /> : null,
     date: createdAt ? formatDateWithDots(createdAt) : "",
-    bodyText: content || "",
+    bodyText: content ? <HtmlContentDisplay htmlContent={content} /> : "",
     font: font || null,
   };
 };

--- a/src/components/RollingPaperCardList/RollingPaperCardList.module.css
+++ b/src/components/RollingPaperCardList/RollingPaperCardList.module.css
@@ -81,15 +81,17 @@
 }
 
 .cardMiddle {
-  flex: 1;
+  display: flex;
+  flex-direction: column;
   width: 100%;
 }
 
 .cardMiddle .content {
+  flex: 1;
   width: 100%;
   height: 6.625rem;
   line-height: var(--line-height-16);
-  overflow: scroll;
+  overflow: hidden;
 }
 
 .cardMiddle hr {
@@ -98,6 +100,7 @@
 }
 
 .createdDate {
+  margin-top: 1rem;
   font-size: var(--font-size-12);
   line-height: 1.125rem;
   color: var(--color-gray-300);
@@ -121,14 +124,11 @@
 
 /* Tablet (768px ~ 1024px) */
 @media (max-width: 1024px) {
-  .cardMiddle .content {
-    height: 6.875rem;
+  .createdDate {
+    margin-top: 1.25rem;
   }
 }
 
 /* Mobile (Max 767px) */
 @media (max-width: 767px) {
-  .cardMiddle .content {
-    height: 3.5rem;
-  }
 }

--- a/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.css
+++ b/src/components/TextEditor/HtmlContentDisplay/HtmlContentDisplay.css
@@ -1,25 +1,27 @@
 .ql-align-right {
   text-align: right;
 }
+
 .ql-align-center {
   text-align: center;
 }
+
 .ql-align-justify {
   text-align: justify;
 }
 
-ol {
+.quill-content ol {
   list-style-type: decimal;
 }
 
-li[data-list] {
+.quill-content li[data-list] {
   margin-left: 1rem;
 }
 
-li[data-list="ordered"] {
+.quill-content li[data-list="ordered"] {
   list-style-type: decimal;
 }
 
-li[data-list="bullet"] {
+.quill-content li[data-list="bullet"] {
   list-style-type: disc;
 }

--- a/src/pages/PostItemPage/PostItemPage.jsx
+++ b/src/pages/PostItemPage/PostItemPage.jsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useRef, useState } from "react";
 
+import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import { Navigate, useLocation, useParams } from "react-router-dom";
 
@@ -228,7 +229,7 @@ const ErrorDisplay = memo(({ onRetry }) => (
 ));
 
 const EmptyDisplay = memo(() => (
-  <div className={styles.errorMessageWrapper}>
+  <div className={clsx(styles.errorMessageWrapper, styles.emptyMessage)}>
     <img src={EmptyPaperplane} alt="보라색 종이비행기" />
     <p>받은 메시지가 없습니다.</p>
   </div>

--- a/src/pages/PostItemPage/PostItemPage.module.css
+++ b/src/pages/PostItemPage/PostItemPage.module.css
@@ -103,7 +103,7 @@
 }
 
 /* Card용 반응형 브레이크 포인트  */
-@media (max-width: 650px) {
+@media (max-width: 675px) {
   .messageContainer {
     grid-template-columns: repeat(1, 1fr);
     gap: 1rem;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Closes #89 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 생성된 롤링페이퍼 페이지 메시지 없을 시 보여지는 카드 배치 수정
- [x] 모달 에디터의 스타일 적용
- [x] EmojiPicker 반응형 모바일 위치 및 크기 조정
- [x] 메시지 등록 페이지 내 리스트 스타일이 중복되어 나타나는 문제 개선 (`HtmlContentDisplay`에 적용한 `.css` 스코프 문제)
- [x] 카드 형태에서 메시지 길이가 길면 나타나는 스크롤 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
